### PR TITLE
Fix QuantAvgPool2d

### DIFF
--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -93,12 +93,7 @@ class QuantAvgPool2d(CustomOp):
         model.set_tensor_datatype(node.output[0], dtype)
 
     def get_accum_size(self):
-        # The maximum of the avg pool is if all inputs are the 2**ibits-1
-        # so the output is (2**ibits-1) * kernel_size * kernel_size
-        # which is then divided by kernel_size * kernel_size
-        # so the output is 2**ibits-1 -> input and output need the same number of bits
-        # ibits = self.get_nodeattr("ibits")
-        # return ibits
+        # Calculate the maximum bit width of the accumulator
         ibits = self.get_nodeattr("ibits")
         k = self.get_nodeattr("kernel")
         max_value = 2**ibits - 1
@@ -107,6 +102,7 @@ class QuantAvgPool2d(CustomOp):
         return max_bit_width
 
     def get_shifts(self):
+        # Calculate the number of bits to shift based on input and output bit widths
         shift_bits = self.get_nodeattr("ibits") - self.get_nodeattr("obits")
         shift_bits = shift_bits if shift_bits >= 0 else 0
         return shift_bits

--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -147,7 +147,6 @@ class QuantAvgPool2d(CustomOp):
         idict = {node.input[0]: inp_values}
         sess = rt.InferenceSession(model_avgpool.SerializeToString())
         result_temp = sess.run(None, idict)
-        # remove scaling introduced by average
         result = np.right_shift(result_temp[0].astype(int), self.get_shifts())
         if self.get_nodeattr("data_layout") == "NHWC":
             result = result.transpose(0, 2, 3, 1)

--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -145,9 +145,8 @@ class QuantAvgPool2d(CustomOp):
         idict = {node.input[0]: inp_values}
         sess = rt.InferenceSession(model_avgpool.SerializeToString())
         result_temp = sess.run(None, idict)
-        result_temp = np.array(result_temp)
         # remove scaling introduced by average
-        result = np.right_shift(result_temp.astype(int), self.get_shifts())
+        result = np.right_shift(result_temp[0].astype(int), self.get_shifts())
         if self.get_nodeattr("data_layout") == "NHWC":
             result = result.transpose(0, 2, 3, 1)
         context[node.output[0]] = result.astype(np.float32)

--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -103,12 +103,18 @@ class QuantAvgPool2d(CustomOp):
 
     def get_shifts(self):
         # Calculate the number of bits to shift based on input and output bit widths
+        # In the worst case, every element of the input vector contains the largest value fitting
+        # the input bit size i.e. 2**ibits-1. Therefore the accumulator will contain the value
+        # (2**ibits-1)*k*k, where k is the kernel size. After the division mandated in the AvgNode
+        # by k*k, the largest value that can be present is (2**ibits-1), which then needs to be
+        # shifted to fit into the output type.
         shift_bits = self.get_nodeattr("ibits") - self.get_nodeattr("obits")
         shift_bits = shift_bits if shift_bits >= 0 else 0
         return shift_bits
 
     def execute_node(self, context, graph):
         # create a standard average pooling node to help calculate the result
+        # Implements: \sum_{i=0}^{k}(\sum_{j=0}^{k} x_{i,j}) / (k*k) >> (ibits - obits)
         node = self.onnx_node
         k = self.get_nodeattr("kernel")
         s = self.get_nodeattr("stride")

--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -97,11 +97,17 @@ class QuantAvgPool2d(CustomOp):
         # so the output is (2**ibits-1) * kernel_size * kernel_size
         # which is then divided by kernel_size * kernel_size
         # so the output is 2**ibits-1 -> input and output need the same number of bits
+        # ibits = self.get_nodeattr("ibits")
+        # return ibits
         ibits = self.get_nodeattr("ibits")
-        return ibits
+        k = self.get_nodeattr("kernel")
+        max_value = 2**ibits - 1
+        max_value = max_value * k * k
+        max_bit_width = int(max_value).bit_length()
+        return max_bit_width
 
     def get_shifts(self):
-        shift_bits = self.get_accum_size() - self.get_nodeattr("obits")
+        shift_bits = self.get_nodeattr("ibits") - self.get_nodeattr("obits")
         shift_bits = shift_bits if shift_bits >= 0 else 0
         return shift_bits
 
@@ -139,6 +145,7 @@ class QuantAvgPool2d(CustomOp):
         idict = {node.input[0]: inp_values}
         sess = rt.InferenceSession(model_avgpool.SerializeToString())
         result_temp = sess.run(None, idict)
+        result_temp = np.array(result_temp)
         # remove scaling introduced by average
         result = np.right_shift(result_temp.astype(int), self.get_shifts())
         if self.get_nodeattr("data_layout") == "NHWC":

--- a/src/qonnx/custom_op/general/trunc.py
+++ b/src/qonnx/custom_op/general/trunc.py
@@ -91,7 +91,7 @@ class Trunc(CustomOp):
 
     def get_integer_datatype(self, model):
         signed = model.get_tensor_datatype(self.onnx_node.input[0]).signed()
-        bit_width = model.get_initializer(self.onnx_node.input[4])
+        bit_width = model.get_initializer(self.onnx_node.input[5])
         bit_width = int(bit_width)
         if bit_width == 1:
             if signed:
@@ -106,7 +106,7 @@ class Trunc(CustomOp):
         return finn_dt
 
     def get_scaled_integer_datatype(self, model):
-        bit_width = model.get_initializer(self.onnx_node.input[4])
+        bit_width = model.get_initializer(self.onnx_node.input[5])
         bit_width = int(bit_width)
         finn_dt = DataType["SCALEDINT<%d>" % (bit_width)]
         return finn_dt
@@ -116,7 +116,7 @@ class Trunc(CustomOp):
         # scale, zero-point and bitwidth must be read from initializers
         scale = model.get_initializer(node.input[1])
         zeropt = model.get_initializer(node.input[2])
-        bitwidth = model.get_initializer(node.input[4])
+        bitwidth = model.get_initializer(node.input[5])
         assert scale is not None, "Found unspecified scale for Trunc node: " + str(node)
         assert zeropt is not None, "Found unspecified zero point for Trunc node: " + str(node)
         assert bitwidth is not None, "Found unspecified output bitwidth for Trunc node: " + str(node)


### PR DESCRIPTION
This PR fixes the QuantAvgPool2d operator and Trunc operator.

With this PR the brevitas and qonnx side of the changes in https://github.com/Xilinx/brevitas/pull/1042 are complete. Now only FINN+ needs to be adapted. (Tracked in https://github.com/eki-project/finn-plus/issues/92)

This PR is also needed for https://github.com/eki-project/finn-plus/pull/94.